### PR TITLE
Change the apt-get upgrade command so it is truly headless

### DIFF
--- a/packages/apt-get/upgrade.sh
+++ b/packages/apt-get/upgrade.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -e
-sudo apt-get -y -qq upgrade
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade


### PR DESCRIPTION
Some updates (namely Grub2) were halting the headless update progress expecting user interaction.  This prevents that.